### PR TITLE
test(routing) Add Router context to App.test.js

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,7 +15,7 @@ const DemoCard = () => (
 )
 
 const NotFound = () => (
-  <div>
+  <div className="not-found">
     <h1>To infinity, and beyond!</h1>
     <p>You are in a maze of twisty little passages, all alike. Go back, while
     you still can. Try <code>/card</code> to see something else.</p>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,12 +1,27 @@
+
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { MemoryRouter } from 'react-router-dom'
+import ReactTestUtils from 'react-dom/test-utils';
+
 import App from './App';
 
-/**
- * NOTE: No "real" tests here yet, as all the App does is render a single, dumb
- * component.
- */
-it('renders without crashing', () => {
-  const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
+it('renders NotFound component by default', () => {
+  const rendered = ReactTestUtils.renderIntoDocument(
+    <MemoryRouter initialEntries={[ '/' ]}>
+      <App />
+    </MemoryRouter>
+  );
+  const el = ReactTestUtils.findRenderedDOMComponentWithClass(rendered, 'not-found');
+  expect(el.tagName.toLowerCase()).toEqual('div');
+});
+
+it('renders ExampleCard component on path "/card"', () => {
+  const rendered = ReactTestUtils.renderIntoDocument(
+    <MemoryRouter initialEntries={[ '/card' ]}>
+      <App />
+    </MemoryRouter>
+  );
+  const el = ReactTestUtils.findRenderedDOMComponentWithClass(rendered, 'card');
+  expect(el.tagName.toLowerCase()).toEqual('div');
 });


### PR DESCRIPTION
This sets the proper context for React Router v4 components such as `<Switch>` and `<Link>`. Without such context, previously working code fails when run in a text context.

Yes, this should have been caught before merging #8. CI would have caught this.